### PR TITLE
Impl

### DIFF
--- a/include/utmatrix.h
+++ b/include/utmatrix.h
@@ -62,66 +62,140 @@ public:
 template <class ValType>
 TVector<ValType>::TVector(int s, int si)
 {
+	if ((si > s)
+		|| ((s - si) > MAX_VECTOR_SIZE)
+		|| (si < 0)
+		) throw 0;
+	Size = s;
+	StartIndex = si;
+	pVector = new ValType[Size - StartIndex];
+	for (int i = 0; i < (Size - StartIndex); i++)
+		pVector[i] = (ValType)0;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> //конструктор копирования
 TVector<ValType>::TVector(const TVector<ValType> &v)
 {
+	if (&v == this)
+		return;
+	Size = v.Size;
+	StartIndex = v.StartIndex;
+	pVector = new ValType[Size - StartIndex];
+	for (int i = 0; i < (Size - StartIndex); i++)
+		pVector[i] = v.pVector[i];
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType>
 TVector<ValType>::~TVector()
 {
+	delete[] pVector;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // доступ
 ValType& TVector<ValType>::operator[](int pos)
 {
+	if (pos < 0
+		|| (pos > (Size)))
+		throw 0;
+	return pVector[pos];
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // сравнение
 bool TVector<ValType>::operator==(const TVector &v) const
 {
+	if (&v == this)
+		return 1;
+	if ((Size == v.Size)
+		&& (StartIndex == v.StartIndex))
+	{
+		for (int i = 0; i < (Size - StartIndex); i++)
+			if (pVector[i] != v.pVector[i])
+				return 0;
+		return 1;
+	}
+	return 0;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // сравнение
 bool TVector<ValType>::operator!=(const TVector &v) const
 {
+	if (v == *this)
+		return 0;
+	return 1;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // присваивание
 TVector<ValType>& TVector<ValType>::operator=(const TVector &v)
 {
+	if (&v != this)
+	{
+		if (!(
+			(Size == v.Size)
+			&& (StartIndex == v.StartIndex)))
+		{
+			Size = v.Size;
+			StartIndex = v.StartIndex;
+			delete[] pVector;
+			pVector = new ValType[Size - StartIndex];
+		}
+		for (int i = 0; i < (Size - StartIndex); i++)
+			pVector[i] = v.pVector[i];
+	}
+	return *this;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // прибавить скаляр
 TVector<ValType> TVector<ValType>::operator+(const ValType &val)
 {
+	TVector<ValType> out(*this);
+	for (int i = 0; i < (Size - StartIndex); i++)
+		out.pVector[i] += val;
+	return out;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // вычесть скаляр
 TVector<ValType> TVector<ValType>::operator-(const ValType &val)
 {
+	return (*this + (-val));
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // умножить на скаляр
 TVector<ValType> TVector<ValType>::operator*(const ValType &val)
 {
+	TVector<ValType> out(*this);
+	for (int i = 0; i < (Size - StartIndex); i++)
+		out.pVector[i] *= val;
+	return out;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // сложение
 TVector<ValType> TVector<ValType>::operator+(const TVector<ValType> &v)
 {
+	if ((v.Size != Size)
+		|| (v.StartIndex != StartIndex)
+		) throw 0;
+	TVector<ValType> out(*this);
+	for (int i = 0; i < (Size - StartIndex); i++)
+		out.pVector[i] += v.pVector[i];
+	return out;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // вычитание
 TVector<ValType> TVector<ValType>::operator-(const TVector<ValType> &v)
 {
+	return (*this + (TVector<ValType> (v) * (-1)));
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // скалярное произведение
 ValType TVector<ValType>::operator*(const TVector<ValType> &v)
 {
+	if ((v.Size != Size)
+		|| (v.StartIndex != StartIndex)
+		) throw 0;
+	ValType out = 0;
+	for (int i = 0; i < (Size - StartIndex); i++)
+		out += pVector[i] * v.pVector[i];
+	return out;
 } /*-------------------------------------------------------------------------*/
 
 
@@ -170,26 +244,31 @@ TMatrix<ValType>::TMatrix(const TVector<TVector<ValType> > &mt):
 template <class ValType> // сравнение
 bool TMatrix<ValType>::operator==(const TMatrix<ValType> &mt) const
 {
+	return false;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // сравнение
 bool TMatrix<ValType>::operator!=(const TMatrix<ValType> &mt) const
 {
+	return false;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // присваивание
 TMatrix<ValType>& TMatrix<ValType>::operator=(const TMatrix<ValType> &mt)
 {
+	return false;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // сложение
 TMatrix<ValType> TMatrix<ValType>::operator+(const TMatrix<ValType> &mt)
 {
+	return false;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // вычитание
 TMatrix<ValType> TMatrix<ValType>::operator-(const TMatrix<ValType> &mt)
 {
+	return mt;
 } /*-------------------------------------------------------------------------*/
 
 // TVector О3 Л2 П4 С6

--- a/include/utmatrix.h
+++ b/include/utmatrix.h
@@ -78,8 +78,6 @@ TVector<ValType>::TVector(int s, int si)
 template <class ValType> //конструктор копирования
 TVector<ValType>::TVector(const TVector<ValType> &v)
 {
-	if (&v == this)
-		return;
 	Size = v.Size;
 	StartIndex = v.StartIndex;
 	pVector = new ValType[(Size - StartIndex)];
@@ -151,7 +149,7 @@ TVector<ValType> TVector<ValType>::operator+(const ValType &val)
 {
 	TVector<ValType> out(*this);
 	for (int i = 0; i < (Size - StartIndex); i++)
-		out.pVector[i] += val;
+    out.pVector[i] = out.pVector[i] + val;
 	return out;
 } /*-------------------------------------------------------------------------*/
 
@@ -166,7 +164,7 @@ TVector<ValType> TVector<ValType>::operator*(const ValType &val)
 {
 	TVector<ValType> out(*this);
 	for (int i = 0; i < (Size - StartIndex); i++)
-		out.pVector[i] *= val;
+    out.pVector[i] = out.pVector[i] * val;
 	return out;
 } /*-------------------------------------------------------------------------*/
 
@@ -178,14 +176,20 @@ TVector<ValType> TVector<ValType>::operator+(const TVector<ValType> &v)
 		) throw 0;
 	TVector<ValType> out(*this);
 	for (int i = 0; i < (Size - StartIndex); i++)
-		out.pVector[i] += v.pVector[i];
+		out.pVector[i] = out.pVector[i] + v.pVector[i];
 	return out;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // вычитание
 TVector<ValType> TVector<ValType>::operator-(const TVector<ValType> &v)
 {
-	return (*this + (TVector<ValType> (v) * (-1)));
+  if ((v.Size != Size)
+    || (v.StartIndex != StartIndex)
+    ) throw 0;
+  TVector<ValType> out(*this);
+  for (int i = 0; i < (Size - StartIndex); i++)
+    out.pVector[i] = out.pVector[i] - v.pVector[i];
+  return out;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // скалярное произведение
@@ -251,16 +255,19 @@ TMatrix<ValType>::TMatrix(const TVector<TVector<ValType> > &mt):
 template <class ValType> // сравнение
 bool TMatrix<ValType>::operator==(const TMatrix<ValType> &mt) const
 {
-	if (&mt == this)
-		return 1;
-	if (Size == mt.Size)
-	{
-		for (int i = 0; i < Size; i++)
-			if (pVector[i] != mt.pVector[i])
-				return 0;
-		return 1;
-	}
-	return 0;
+	//if (&mt == this)
+	//	return 1;
+	//if (Size == mt.Size)
+	//{
+  //
+	//	for (int i = 0; i < Size; i++)
+	//		if (pVector[i] != mt.pVector[i])
+	//			return 0;
+	//	return 1;
+	//}
+	//return 0;
+  //return ((TVector<TVector<ValType> >)(*this)) == mt;
+  return TVector<TVector<ValType> >::operator==(mt);
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // сравнение
@@ -291,19 +298,21 @@ TMatrix<ValType>& TMatrix<ValType>::operator=(const TMatrix<ValType> &mt)
 template <class ValType> // сложение
 TMatrix<ValType> TMatrix<ValType>::operator+(const TMatrix<ValType> &mt)
 {
-	TMatrix<ValType> out(*this);
-	for (int i = 0; i < Size; i++)
-		out.pVector[i] = out.pVector[i] + mt.pVector[i];
-	return out;
+	//TMatrix<ValType> out(*this);
+	//for (int i = 0; i < Size; i++)
+	//	out.pVector[i] = out.pVector[i] + mt.pVector[i];
+	//return out;
+  return TVector<TVector<ValType> >::operator+(mt);
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // вычитание
 TMatrix<ValType> TMatrix<ValType>::operator-(const TMatrix<ValType> &mt)
 {
-	TMatrix<ValType> out(*this);
-	for (int i = 0; i < Size; i++)
-		out.pVector[i] = out.pVector[i] - mt.pVector[i];
-	return out;
+	//TMatrix<ValType> out(*this);
+	//for (int i = 0; i < Size; i++)
+	//	out.pVector[i] = out.pVector[i] - mt.pVector[i];
+	//return out;
+  return TVector<TVector<ValType> >::operator-(mt);
 } /*-------------------------------------------------------------------------*/
 
 // TVector О3 Л2 П4 С6

--- a/include/utmatrix.h
+++ b/include/utmatrix.h
@@ -47,14 +47,16 @@ public:
   // ввод-вывод
   friend istream& operator>>(istream &in, TVector &v)
   {
-    for (int i = 0; i < v.Size; i++)
+    for (int i = 0; i < (v.Size - v.StartIndex); i++)
       in >> v.pVector[i];
     return in;
   }
   friend ostream& operator<<(ostream &out, const TVector &v)
   {
-    for (int i = 0; i < v.Size; i++)
-      out << v.pVector[i] << ' ';
+	  for (int i = 0; i < v.StartIndex; i++)
+		  out << 0 << '\t';
+    for (int i = 0; i < (v.Size - v.StartIndex); i++)
+      out << v.pVector[i] << '\t';
     return out;
   }
 };
@@ -68,7 +70,7 @@ TVector<ValType>::TVector(int s, int si)
 		) throw 0;
 	Size = s;
 	StartIndex = si;
-	pVector = new ValType[Size - StartIndex];
+	pVector = new ValType[(Size - StartIndex)];
 	for (int i = 0; i < (Size - StartIndex); i++)
 		pVector[i] = (ValType)0;
 } /*-------------------------------------------------------------------------*/
@@ -80,7 +82,7 @@ TVector<ValType>::TVector(const TVector<ValType> &v)
 		return;
 	Size = v.Size;
 	StartIndex = v.StartIndex;
-	pVector = new ValType[Size - StartIndex];
+	pVector = new ValType[(Size - StartIndex)];
 	for (int i = 0; i < (Size - StartIndex); i++)
 		pVector[i] = v.pVector[i];
 } /*-------------------------------------------------------------------------*/
@@ -94,10 +96,10 @@ TVector<ValType>::~TVector()
 template <class ValType> // доступ
 ValType& TVector<ValType>::operator[](int pos)
 {
-	if (pos < 0
+	if (pos < StartIndex
 		|| (pos > (Size)))
 		throw 0;
-	return pVector[pos + StartIndex];
+	return pVector[pos - StartIndex];
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // сравнение

--- a/include/utmatrix.h
+++ b/include/utmatrix.h
@@ -97,7 +97,7 @@ ValType& TVector<ValType>::operator[](int pos)
 	if (pos < 0
 		|| (pos > (Size)))
 		throw 0;
-	return pVector[pos];
+	return pVector[pos + StartIndex];
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // сравнение
@@ -231,6 +231,11 @@ public:
 template <class ValType>
 TMatrix<ValType>::TMatrix(int s): TVector<TVector<ValType> >(s)
 {
+	if (s > MAX_MATRIX_SIZE)
+		throw 0;
+	for (int i = 0; i < s; i++)
+		pVector[i] = TVector<ValType>(s, i);
+
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // конструктор копирования
@@ -244,31 +249,59 @@ TMatrix<ValType>::TMatrix(const TVector<TVector<ValType> > &mt):
 template <class ValType> // сравнение
 bool TMatrix<ValType>::operator==(const TMatrix<ValType> &mt) const
 {
-	return false;
+	if (&mt == this)
+		return 1;
+	if (Size == mt.Size)
+	{
+		for (int i = 0; i < Size; i++)
+			if (pVector[i] != mt.pVector[i])
+				return 0;
+		return 1;
+	}
+	return 0;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // сравнение
 bool TMatrix<ValType>::operator!=(const TMatrix<ValType> &mt) const
 {
-	return false;
+	if (mt == *this)
+		return 0;
+	return 1;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // присваивание
 TMatrix<ValType>& TMatrix<ValType>::operator=(const TMatrix<ValType> &mt)
 {
-	return false;
+	if (&mt != this)
+	{
+		if (Size != mt.Size)
+		{
+			Size = mt.Size;
+			delete[] pVector;
+			pVector = new TVector<ValType>[Size];
+		}
+		for (int i = 0; i < Size; i++)
+			pVector[i] = mt.pVector[i];
+	}
+	return *this;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // сложение
 TMatrix<ValType> TMatrix<ValType>::operator+(const TMatrix<ValType> &mt)
 {
-	return false;
+	TMatrix<ValType> out(*this);
+	for (int i = 0; i < Size; i++)
+		out.pVector[i] = out.pVector[i] + mt.pVector[i];
+	return out;
 } /*-------------------------------------------------------------------------*/
 
 template <class ValType> // вычитание
 TMatrix<ValType> TMatrix<ValType>::operator-(const TMatrix<ValType> &mt)
 {
-	return mt;
+	TMatrix<ValType> out(*this);
+	for (int i = 0; i < Size; i++)
+		out.pVector[i] = out.pVector[i] - mt.pVector[i];
+	return out;
 } /*-------------------------------------------------------------------------*/
 
 // TVector О3 Л2 П4 С6

--- a/test/test_tmatrix.cpp
+++ b/test/test_tmatrix.cpp
@@ -26,86 +26,156 @@ TEST(TMatrix, can_create_copied_matrix)
 
 TEST(TMatrix, copied_matrix_is_equal_to_source_one)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2);
+	TMatrix<int> b(v);
+
+	EXPECT_EQ(v, b);
 }
 
 TEST(TMatrix, copied_matrix_has_its_own_memory)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2);
+	TMatrix<int> b(v);
+	v[1][1] = 1;
+
+	EXPECT_NE(v[1][1], b[1][1]);
 }
 
 TEST(TMatrix, can_get_size)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2);
+
+	EXPECT_EQ(2, v.GetSize());
 }
 
 TEST(TMatrix, can_set_and_get_element)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(4);
+	v[2][3] = 4;
+
+	EXPECT_EQ(4, v[2][3]);
 }
 
 TEST(TMatrix, throws_when_set_element_with_negative_index)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(4);
+
+	ASSERT_ANY_THROW(v[-1][-1] = 2);
 }
 
 TEST(TMatrix, throws_when_set_element_with_too_large_index)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(4);
+
+	ASSERT_ANY_THROW(v[0][6] = 2);
 }
 
 TEST(TMatrix, can_assign_matrix_to_itself)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2);
+	v[0][0] = 1;
+	v[0][1] = 2;
+	v = v;
+
+	EXPECT_EQ(v, v);
 }
 
 TEST(TMatrix, can_assign_matrices_of_equal_size)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2), b(2);
+	v[0][0] = 1;
+	v[0][1] = 2;
+	b = v;
+
+	EXPECT_EQ(v, b);
 }
 
 TEST(TMatrix, assign_operator_change_matrix_size)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(3), b(2);
+	v[0][0] = 1;
+	v[0][1] = 2;
+	v[0][2] = 3;
+	b = v;
+
+	EXPECT_EQ(3, b.GetSize());
 }
 
 TEST(TMatrix, can_assign_matrices_of_different_size)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(3), b(2);
+	v[0][0] = 1;
+	v[0][1] = 2;
+	v[0][2] = 3;
+	b = v;
+
+	EXPECT_EQ(v, b);
 }
 
 TEST(TMatrix, compare_equal_matrices_return_true)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2), b(2);
+	v[0][0] = 1;
+	v[0][1] = 2;
+	b[0][0] = 1;
+	b[0][1] = 2;
+
+	EXPECT_EQ(v, b);
 }
 
 TEST(TMatrix, compare_matrix_with_itself_return_true)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2);
+
+	EXPECT_EQ(v, v);
 }
 
 TEST(TMatrix, matrices_with_different_size_are_not_equal)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2), b(4);
+
+	EXPECT_NE(v, b);
 }
 
 TEST(TMatrix, can_add_matrices_with_equal_size)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2), b(2), c(2);
+	v[0][0] = 1;
+	b[0][0] = 2;
+	v[0][1] = 3;
+	b[0][1] = 3;
+	v = v + b;
+	c[0][0] = 3;
+	c[0][1] = 6;
+
+	EXPECT_EQ(c, v);
 }
 
 TEST(TMatrix, cant_add_matrices_with_not_equal_size)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2), b(3);
+
+	ASSERT_ANY_THROW(v = v + b);
 }
 
 TEST(TMatrix, can_subtract_matrices_with_equal_size)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2), b(2), c(2);
+	v[0][0] = 1;
+	b[0][0] = 2;
+	v[0][1] = 3;
+	b[0][1] = 3;
+	v = v - b;
+	c[0][0] = -1;
+	c[0][1] = 0;
+
+	EXPECT_EQ(c, v);
 }
 
 TEST(TMatrix, cant_subtract_matrixes_with_not_equal_size)
 {
-  ADD_FAILURE();
+	TMatrix<int> v(2), b(3);
+
+	ASSERT_ANY_THROW(v = v - b);
 }
 

--- a/test/test_tvector.cpp
+++ b/test/test_tvector.cpp
@@ -31,12 +31,19 @@ TEST(TVector, can_create_copied_vector)
 
 TEST(TVector, copied_vector_is_equal_to_source_one)
 {
-  ADD_FAILURE();
+	TVector<int> v(2);
+	TVector<int> b(v);
+
+	EXPECT_EQ(v, b);
 }
 
 TEST(TVector, copied_vector_has_its_own_memory)
 {
-  ADD_FAILURE();
+	TVector<int> v(2);
+	TVector<int> b(v);
+	v[0] = 1;
+
+	EXPECT_NE(v[0], b[0]);
 }
 
 TEST(TVector, can_get_size)
@@ -63,91 +70,159 @@ TEST(TVector, can_set_and_get_element)
 
 TEST(TVector, throws_when_set_element_with_negative_index)
 {
-  ADD_FAILURE();
+	TVector<int> v(4);
+
+	ASSERT_ANY_THROW(v[-1] = 2);
 }
 
 TEST(TVector, throws_when_set_element_with_too_large_index)
 {
-  ADD_FAILURE();
+	TVector<int> v(4);
+
+	ASSERT_ANY_THROW(v[6] = 2);
 }
 
 TEST(TVector, can_assign_vector_to_itself)
 {
-  ADD_FAILURE();
+	TVector<int> v(2);
+	v[0] = 1;
+	v[1] = 2;
+	v = v;
+
+	EXPECT_EQ(v, v);
 }
 
 TEST(TVector, can_assign_vectors_of_equal_size)
 {
-  ADD_FAILURE();
+	TVector<int> v(2), b(2);
+	v[0] = 1;
+	v[1] = 2;
+	b = v;
+
+	EXPECT_EQ(v, b);
 }
 
 TEST(TVector, assign_operator_change_vector_size)
 {
-  ADD_FAILURE();
+	TVector<int> v(3), b(2);
+	v[0] = 1;
+	v[1] = 2;
+	v[2] = 3;
+	b = v;
+
+	EXPECT_EQ(3, b.GetSize());
 }
 
 TEST(TVector, can_assign_vectors_of_different_size)
 {
-  ADD_FAILURE();
+	TVector<int> v(3), b(2);
+	v[0] = 1;
+	v[1] = 2;
+	v[2] = 3;
+	b = v;
+
+	EXPECT_EQ(v, b);
 }
 
 TEST(TVector, compare_equal_vectors_return_true)
 {
-  ADD_FAILURE();
+	TVector<int> v(2), b(2);
+	v[0] = 1;
+	v[1] = 2;
+	b[0] = 1;
+	b[1] = 2;
+
+	EXPECT_EQ(v, b);
 }
 
 TEST(TVector, compare_vector_with_itself_return_true)
 {
-  ADD_FAILURE();
+	TVector<int> v(2);
+
+	EXPECT_EQ(v, v);
 }
 
 TEST(TVector, vectors_with_different_size_are_not_equal)
 {
-  ADD_FAILURE();
+	TVector<int> v(2), b(4);
+
+	EXPECT_NE(v, b);
 }
 
 TEST(TVector, can_add_scalar_to_vector)
 {
-  ADD_FAILURE();
+	TVector<int> v(2);
+	v = v + 1;
+
+	EXPECT_EQ(1, v[1]);
 }
 
 TEST(TVector, can_subtract_scalar_from_vector)
 {
-  ADD_FAILURE();
+	TVector<int> v(2);
+	v = v - 1;
+
+	EXPECT_EQ(-1, v[1]);
 }
 
 TEST(TVector, can_multiply_scalar_by_vector)
 {
-  ADD_FAILURE();
+	TVector<int> v(2);
+	v = v + 1;
+	v = v * 2;
+
+	EXPECT_EQ(2, v[1]);
 }
 
 TEST(TVector, can_add_vectors_with_equal_size)
 {
-  ADD_FAILURE();
+	TVector<int> v(2), b(2), c(2);
+	v = v + 1;
+	b = b + 2;
+	v = v + b;
+	c = c + 3;
+
+	EXPECT_EQ(c, v);
 }
 
 TEST(TVector, cant_add_vectors_with_not_equal_size)
 {
-  ADD_FAILURE();
+	TVector<int> v(2), b(3);
+
+	ASSERT_ANY_THROW(v = v + b);
 }
 
 TEST(TVector, can_subtract_vectors_with_equal_size)
 {
-  ADD_FAILURE();
+	TVector<int> v(2), b(2), c(2);
+	v = v + 1;
+	b = b + 2;
+	v = v - b;
+	c = c - 1;
+
+	EXPECT_EQ(c, v);
 }
 
 TEST(TVector, cant_subtract_vectors_with_not_equal_size)
 {
-  ADD_FAILURE();
+	TVector<int> v(2), b(3);
+
+	ASSERT_ANY_THROW(v = v - b);
 }
 
 TEST(TVector, can_multiply_vectors_with_equal_size)
 {
-  ADD_FAILURE();
+	TVector<int> v(2), b(2);
+	v = v + 1;
+	b = b + 2;
+
+	EXPECT_EQ(4, v * b);
 }
 
 TEST(TVector, cant_multiply_vectors_with_not_equal_size)
 {
-  ADD_FAILURE();
+	TVector<int> v(2), b(3);
+
+	ASSERT_ANY_THROW(v = v * b);
 }
 


### PR DESCRIPTION
Не уверен, что можно менять реализацию метода вывода вектора на экран. Моя мотивация написать свою версию такая: метод пытается получить доступ к массиву pVector напрямую, игнорируя особенности его хранения, из-за чего работает неверно. Например, для вектора {0, 1, 2, 3} с начальным индексом 1 и размерностью 5 этот метод в его изначально предложенной реализации будет выводить на экран нечто вида: 0 1 2 3 -123854313.
Все остальное работает.